### PR TITLE
reduce the rel4test total run time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 ]
 [profile.release]
 lto = true
+opt-level = 3
 
 [patch.'https://github.com/reL4team2/driver-collect.git']
 driver-collect = { path = "driver-collect" }

--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -129,6 +129,7 @@ pub fn mask_interrupt(disable: bool, irq: usize) {
 }
 
 #[cfg(target_arch = "riscv64")]
+#[inline]
 pub fn isIRQPending() -> bool {
     let sip = read_sip();
     if (sip & (BIT!(SIP_STIP) | BIT!(SIP_SEIP))) != 0 {

--- a/sel4_task/src/scheduler.rs
+++ b/sel4_task/src/scheduler.rs
@@ -145,7 +145,7 @@ pub static mut ksReadyQueuesL2Bitmap: [[usize; L2_BITMAP_SIZE]; CONFIG_NUM_DOMAI
 pub static mut ksReadyQueuesL1Bitmap: [usize; CONFIG_NUM_DOMAINS] = [0; CONFIG_NUM_DOMAINS];
 
 #[no_mangle]
-// #[link_section = ".boot.bss"]
+#[link_section = ".boot.bss"]
 pub static mut ksWorkUnitsCompleted: usize = 0;
 
 // #[link_section = ".boot.bss"]


### PR DESCRIPTION
reduce the rel4test total run time, now the execution time is the same as the old version