### PR TITLE
使用 smc 指令替换 hvc

### DIFF
--- a/kernel/src/syscall/invocation/decode/arch/aarch64.rs
+++ b/kernel/src/syscall/invocation/decode/arch/aarch64.rs
@@ -1182,7 +1182,7 @@ fn invoke_smc_call(buffer: &seL4_IPCBuffer, call: bool) -> exception_t {
             "mov x6, {6} \n",
             "mov x7, {7} \n",
 
-            "hvc #0 \n",
+            "smc #0 \n",
             "mov {0}, x0 \n",
             "mov {1}, x1 \n",
             "mov {2}, x2 \n",

--- a/sel4_common/src/arch/aarch64/mod.rs
+++ b/sel4_common/src/arch/aarch64/mod.rs
@@ -73,13 +73,28 @@ fn psci_hvc_call(func: u32, arg0: usize, arg1: usize, arg2: usize) -> usize {
     ret
 }
 
+/// psci "smc" method call
+fn psci_smc_call(func: u32, arg0: usize, arg1: usize, arg2: usize) -> usize {
+    let ret;
+    unsafe {
+        core::arch::asm!(
+            "smc #0",
+            inlateout("x0") func as usize => ret,
+            in("x1") arg0,
+            in("x2") arg1,
+            in("x3") arg2,
+        )
+    }
+    ret
+}
+
 fn psci_call(func: u32, arg0: usize, arg1: usize, arg2: usize) -> Result<(), PsciError> {
     // let ret = match axconfig::PSCI_METHOD {
     //     "smc" => arm_smccc_smc(func, arg0, arg1, arg2),
     //     "hvc" => psci_hvc_call(func, arg0, arg1, arg2),
     //     _ => panic!("Unknown PSCI method: {}", axconfig::PSCI_METHOD),
     // };
-    let ret = psci_hvc_call(func, arg0, arg1, arg2);
+    let ret = psci_smc_call(func, arg0, arg1, arg2);
     if ret == 0 {
         Ok(())
     } else {


### PR DESCRIPTION
因为 elf loader smp 模式只支持 smc psci，为了统一，把 rel4 中的 hvc 指令都替换成 smc

同时我修改了 arm machine，从 virt 改到 virt,virtualization=on，这样默认使用 smc psci