### PR TITLE
解决了 riscv smp 中，无法重置远端核心当前进程的 bug；把 riscv smp 测试也加到 CI 中

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [qemu-arm-virt]
+        platform: [qemu-arm-virt, spike]
         include:
           - platform: qemu-arm-virt
             arch: aarch64
@@ -295,8 +295,8 @@ jobs:
         env:
           ARCH: ${{ matrix.arch  }}
           PLATFORM: ${{ matrix.platform }}
-        run: cd rel4_kernel/build && ./simulate --cpu-num 4 -M  virt,virtualization=on > 1.log
-        timeout-minutes: 20
+        run: cd rel4_kernel/build && ./simulate --cpu-num 4 > 1.log
+        timeout-minutes: 25
         continue-on-error: true
       - run: cat rel4_kernel/build/1.log
       - name: Check Result

--- a/kernel/src/arch/riscv/c_traps.rs
+++ b/kernel/src/arch/riscv/c_traps.rs
@@ -198,7 +198,7 @@ pub fn c_handle_interrupt() {
 #[no_mangle]
 pub fn c_handle_exception() {
     #[cfg(feature = "enable_smp")]
-    clh_lock_acquire(cpu_id(), true);
+    clh_lock_acquire(cpu_id(), false);
     // if hart_id() == 0 {
     //     debug!("c_handle_exception");
     // }
@@ -243,7 +243,7 @@ pub fn c_handle_exception() {
 #[no_mangle]
 pub fn c_handle_syscall(_cptr: usize, _msgInfo: usize, syscall: usize) {
     #[cfg(feature = "enable_smp")]
-    clh_lock_acquire(cpu_id(), true);
+    clh_lock_acquire(cpu_id(), false);
     // if hart_id() == 0 {
     //     debug!("c_handle_syscall: syscall: {},", syscall as isize);
     // }


### PR DESCRIPTION
之前存在的 bug，不是核间通信的机制有问题，而是写错了，handle_syscall 的时候也使用了 irq_lock，而不是 sys_lock，导致没有进入远端核心进程处理流程。